### PR TITLE
ENG-757: Run npx codesee@latest vs. npx codesee

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1900,7 +1900,7 @@ async function runCodeseeDetectLanguages() {
     },
   };
 
-  const args = ["codesee", "detect-languages"];
+  const args = ["codesee@latest", "detect-languages"];
   const runExitCode = await exec.exec("npx", args, execOptions);
 
   return runExitCode;

--- a/src/action.js
+++ b/src/action.js
@@ -11,7 +11,7 @@ async function runCodeseeDetectLanguages() {
     },
   };
 
-  const args = ["codesee", "detect-languages"];
+  const args = ["codesee@latest", "detect-languages"];
   const runExitCode = await exec.exec("npx", args, execOptions);
 
   return runExitCode;


### PR DESCRIPTION
We think this will fix a bug where `npx codesee` was failing
with:
```
sh: 1: codesee: not found
```